### PR TITLE
Replacing a rm+mv with a cp operation during the update installation

### DIFF
--- a/src/upgrd/upgrd.hxx
+++ b/src/upgrd/upgrd.hxx
@@ -217,8 +217,7 @@ namespace upgrd {
                     bp::spawn(system_shell, "/c", str_cmd.data());
 
                     #else 
-                    auto str_cmd = "sleep 3; rm "s + _app_path.generic_string() + ";"
-                      + "mv " + upgraded_app.generic_string() + " " + _app_path.generic_string() + ";";
+                    auto str_cmd = "sleep 3; " + "cp " + upgraded_app.generic_string() + " " + _app_path.generic_string() + ";";
 
                     bp::spawn(system_shell, "-c", str_cmd.data());
 

--- a/src/upgrd/upgrd.hxx
+++ b/src/upgrd/upgrd.hxx
@@ -217,7 +217,7 @@ namespace upgrd {
                     bp::spawn(system_shell, "/c", str_cmd.data());
 
                     #else 
-                    auto str_cmd = "sleep 3; " + "cp " + upgraded_app.generic_string() + " " + _app_path.generic_string() + ";";
+                    auto str_cmd = "sleep 3; cp " + upgraded_app.generic_string() + " " + _app_path.generic_string() + ";";
 
                     bp::spawn(system_shell, "-c", str_cmd.data());
 


### PR DESCRIPTION
...to enable in-place overwriting of the executable on macOS and Linux to match the changes in the install scripts in `tipi-build/cli`