### PR TITLE
Cacheable tipi deps

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,14 +1,14 @@
 {
   "tipi-build/zip" : { "@" : "feature/set_time_write_utc" } 
-
-  , "nxxm/gh" : { "@" : "feature/add-get-release-by-tag",
-    "requires" : {
-       "nxxm/xxhr" : { "@" : "feature/cpr-backend" }
-       , "cpp-pre/json" : { "@" : "feature/fix-struct-names-windows"  }
-       , "cpp-pre/type_traits" : {   }
-    }
-  } 
-  , "cpp-pre/file" : {}
-  , "nxxm/cli_widgets" : { "@" : "feature/remove-boostorg-predef"}
-  , "platform" : [ "Boost::system", "Boost::filesystem" ]
+  , "nxxm/gh" : { "@" : "feature/move-to-native-tipi-deps" } 
+  , "cpp-pre/file" : { "@" : "feature/move-to-native-tipi-deps" }
+  , "nxxm/cli_widgets" : { "@" : "feature/move-to-native-tipi-deps"}
+  , "tipi-deps/boost" : {
+      "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
+    , "@" : "v1.80.0-without-submodules"
+    , "u" : true
+    , "opts" : "set(BOOST_INCLUDE_LIBRARIES system filesystem)"
+    , "packages" : ["boost_system", "boost_filesystem"]
+    , "targets" : ["Boost::system", "Boost::filesystem"]
+  }
 }

--- a/src/shipxx/shipxx.hxx
+++ b/src/shipxx/shipxx.hxx
@@ -19,7 +19,7 @@ namespace shipxx {
   namespace detail {
     inline void extract(fs::path file, fs::path out) {
       auto on_extract_entry = [](const char *filename, void *) {
-        log::debug() << "extracted " << filename << std::endl;
+        std::cout << "extracted " << filename << std::endl;
         return 0;
       };
 
@@ -28,11 +28,11 @@ namespace shipxx {
       extraction_result =
           zip_extract(file.generic_string().data(), out.generic_string().data(), on_extract_entry, nullptr);
       if (extraction_result < 0) {
-        log::error() << "An error while extracting the files occurred : " << std::strerror(errno);
+        std::cout << "An error while extracting the files occurred : " << std::strerror(errno);
 
         switch (errno) {
         case EACCES:
-        log::error() << "Probably that nxxm cannot write to the root of the disk. \n You can choose where nxxm writes by changing this environment variable: $env:NXXM_HOME_DIR " ;
+        std::cout << "Probably that nxxm cannot write to the root of the disk. \n You can choose where nxxm writes by changing this environment variable: $env:NXXM_HOME_DIR " ;
           break;
         }
       }


### PR DESCRIPTION
Changes to tipi deps file to build only with cacheable dependencies (no platform libs anymore)